### PR TITLE
UX: Make the gear button match other composer buttons

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -297,11 +297,10 @@ section.avatars.clearfix {
     background: dark-light-diff($primary, $secondary, 60%, -50%);
   }
   .d-editor-button-bar .toolbar-popup-menu-options .btn.select-kit-header {
-    padding: 0 8px;
+    padding: 0.5em 0.65em;
     @media screen and (max-width: 400px) {
-      padding: 0 0.25em;
+      padding: 0.5em 0.25em;
     }
-    height: 25px;
   }
   .composer-actions {
     button.dropdown-select-box-header {


### PR DESCRIPTION
Before / After

<img width="219" alt="Screen Shot 2021-12-04 at 17 51 10" src="https://user-images.githubusercontent.com/66961/144717644-749331d4-21c5-4b72-87dc-e4ccbe5255da.png"> <img width="219" alt="Screen Shot 2021-12-04 at 17 51 23" src="https://user-images.githubusercontent.com/66961/144717647-3d89ed3d-da29-45c8-8c00-7f7d1fa00281.png">


