### PR TITLE
UX: Add sidebar styling

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -18,6 +18,8 @@
   }
 }
 
+@import "sidebar";
+
 body {
   background: dark-light-diff($primary, $secondary, 90%, -95%);
 }
@@ -459,7 +461,7 @@ td.main-link {
   border-radius: 5px;
 }
 
-.btn:not(.bulk-select) {
+.btn:not(.bulk-select, .sidebar-section-header) {
   border-radius: 5px;
   border: 1px solid dark-light-diff($primary, $secondary, 50%, -70%) !important;
   box-shadow: inset 0 1px 2px rgba($secondary, 0.5),

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,0 +1,16 @@
+.sidebar-wrapper {
+  background: var(--secondary);
+  border-radius: 5px;
+  box-shadow: 2px 2px 8px rgba(var(--primary-rgb), 0.12);
+  border: 1px solid var(--primary-300);
+  margin-block: 2.4em;
+
+  .sidebar-section-wrapper
+    .sidebar-section-header-wrapper
+    .sidebar-section-header-button {
+    border-radius: 5px;
+    border: 1px solid var(--primary-500);
+    box-shadow: inset 0 1px 2px rgba(var(--secondary-rgb), 0.5),
+      inset 0 -1px 2px rgba(var(--primary-rgb), 0.25);
+  }
+}


### PR DESCRIPTION
This PR adds styling for Discourse's new sidebar.

**Before:**
<img width="1512" alt="Screen Shot 2022-08-31 at 10 23 49 AM" src="https://user-images.githubusercontent.com/30090424/187742740-ed6854e5-9503-4627-b106-a18eedaf2a2e.png">

**After**
<img width="1512" alt="Screen Shot 2022-08-31 at 10 34 27 AM" src="https://user-images.githubusercontent.com/30090424/187742925-dcaf0d85-3c61-4de3-a45a-dc11eb907606.png">

